### PR TITLE
Function to get predicted pitch from new BPM

### DIFF
--- a/objects/oTestBPM/Create_0.gml
+++ b/objects/oTestBPM/Create_0.gml
@@ -2,12 +2,14 @@
 
 voice = undefined;
 
-var _bpm = 4 * (60 / audio_sound_length(sndSync0));
-VinylSetupBPM(sndSync0, _bpm);
-VinylSetupBPM(sndSync1, _bpm);
-VinylSetupBPM(sndSync2, _bpm);
-VinylSetupBPM(sndSync3, _bpm);
+originalBPM = 4 * (60 / audio_sound_length(sndSync0));
+VinylSetupBPM(sndSync0, originalBPM);
+VinylSetupBPM(sndSync1, originalBPM);
+VinylSetupBPM(sndSync2, originalBPM);
+VinylSetupBPM(sndSync3, originalBPM);
 
-VinylSetupShuffle("bpmShuffle", [sndSync0, sndSync1, sndSync2, sndSync3], true);
-VinylSetupHLT("bpmHLT", sndSync0, sndSync1, sndSync2);
-VinylSetupBlend("bpmBlend", [sndSync0, sndSync1, sndSync2, sndSync3], true);
+bpm = originalBPM;
+
+VinylSetupShuffle("bpmShuffle", [sndSync0, sndSync1, sndSync2, sndSync3], 1, 1, undefined, VINYL_DEFAULT_MIX, undefined, undefined, undefined, originalBPM);
+VinylSetupHLT("bpmHLT", sndSync0, sndSync1, sndSync2, 1, VINYL_DEFAULT_MIX, undefined, undefined, undefined, originalBPM);
+VinylSetupBlend("bpmBlend", [sndSync0, sndSync1, sndSync2, sndSync3], true, 1, undefined, VINYL_DEFAULT_MIX, undefined, undefined, undefined, originalBPM);

--- a/objects/oTestBPM/Draw_0.gml
+++ b/objects/oTestBPM/Draw_0.gml
@@ -12,19 +12,22 @@ UIButtonInline("Simple", function()
 {
     VinylStop(voice);
     voice = VinylPlay(sndSync1, true);
-    VinylSetPitch(voice, 0.5);
+    VinylSetPitch(voice, 1);
+    bpm = originalBPM;
 });
 UIButtonInline("Shuffle", function()
 {
     VinylStop(voice);
     voice = VinylPlay("bpmShuffle", true);
-    VinylSetPitch(voice, 0.5);
+    VinylSetPitch(voice, 1);
+    bpm = originalBPM;
 });
 UIButtonInline("HLT", function()
 {
     VinylStop(voice);
     voice = VinylPlay("bpmHLT", true);
-    VinylSetPitch(voice, 0.5);
+    VinylSetPitch(voice, 1);
+    bpm = originalBPM;
 });
 UIButtonInline("Blend", function()
 {
@@ -37,6 +40,8 @@ UIButtonInline("Blend", function()
         VinylSetBlendMemberGain(voice, _i, 1);
         ++_i;
     }
+    
+    bpm = originalBPM;
 });
 UINewline();
 UIButtonInline("Pause", function()
@@ -55,8 +60,22 @@ UIButtonInline("Stop", function()
 {
     VinylStop(voice);
 });
+UIButtonInline("Change BPM", function()
+{
+    if (bpm == originalBPM)
+    {
+        bpm = originalBPM * 2;
+    }
+    else
+    {
+        bpm = originalBPM;
+    }
+    
+    var _pitchMultiplier = VinylGetPitchForBPM("bpmShuffle", bpm);
+    VinylSetPitch(voice, _pitchMultiplier, 100);
+});
 UINewline();
-UIText($"track position   = {VinylGetTrackPosition(voice)}\nbeat this step   = {VinylGetBeatThisStep(voice)}\nbeat count       = {VinylGetBeatCount(voice)}\nbeat distance    = {VinylGetBeatDistance(voice, false)}\nbeat dist (secs) = {VinylGetBeatDistance(voice)}");
+UIText($"track position   = {VinylGetTrackPosition(voice)}\nbeat this step   = {VinylGetBeatThisStep(voice)}\nbeat count       = {VinylGetBeatCount(voice)}\nbeat distance    = {VinylGetBeatDistance(voice, false)}\nbeat dist (secs) = {VinylGetBeatDistance(voice)}\ncurrent bpm = {bpm}\ncurrent pitch = {VinylGetPitch(voice)}");
 
 if (VinylGetBeatThisStep(voice))
 {

--- a/objects/oTestBPM/Draw_0.gml
+++ b/objects/oTestBPM/Draw_0.gml
@@ -75,7 +75,7 @@ UIButtonInline("Change BPM", function()
     VinylSetPitch(voice, _pitchMultiplier, 100);
 });
 UINewline();
-UIText($"track position   = {VinylGetTrackPosition(voice)}\nbeat this step   = {VinylGetBeatThisStep(voice)}\nbeat count       = {VinylGetBeatCount(voice)}\nbeat distance    = {VinylGetBeatDistance(voice, false)}\nbeat dist (secs) = {VinylGetBeatDistance(voice)}\ncurrent bpm = {bpm}\ncurrent pitch = {VinylGetPitch(voice)}");
+UIText($"track position   = {VinylGetTrackPosition(voice)}\nbeat this step   = {VinylGetBeatThisStep(voice)}\nbeat count       = {VinylGetBeatCount(voice)}\nbeat distance    = {VinylGetBeatDistance(voice, false)}\nbeat dist (secs) = {VinylGetBeatDistance(voice)}\ncurrent bpm      = {bpm}\ncurrent pitch    = {VinylGetPitch(voice)}");
 
 if (VinylGetBeatThisStep(voice))
 {

--- a/scripts/VinylGetPitchForBPM/VinylGetPitchForBPM.gml
+++ b/scripts/VinylGetPitchForBPM/VinylGetPitchForBPM.gml
@@ -1,0 +1,52 @@
+// Feather disable all
+
+/// Returns a pitch multiplier for a new BPM based on the base BPM of the voice or pattern.
+///
+/// @param voiceOrPattern
+/// @param newBPM
+
+function VinylGetPitchForBPM(_voiceOrPattern, _newBPM)
+{
+    static _patternMap = __VinylSystem().__patternMap;
+    static _voiceToStructMap = __VinylSystem().__voiceToStructMap;
+    
+    var _oldBPM = undefined;
+    if (is_handle(_voiceOrPattern))
+    {
+        _oldBPM = __VinylEnsurePatternSound(_voiceOrPattern).__bpm;
+    }
+    else if (is_string(_voiceOrPattern))
+    {
+        var _patternStruct = _patternMap[? _voiceOrPattern];
+        if (_patternStruct != undefined)
+        {
+            _oldBPM = _patternStruct.__bpm;
+        }
+        else
+        {
+            __VinylError("Pattern \"", _voiceOrPattern, "\" not found");
+        }
+    }
+    else
+    {
+        var _voiceStruct = _voiceToStructMap[? _voiceOrPattern];
+        if (_voiceStruct != undefined)
+        {
+            _oldBPM = _voiceStruct.__GetBPM();
+        }
+        else
+        {
+            __VinylError("Datatype not supported (", typeof(_voiceOrPattern), ")");
+        }
+    }
+    
+    if (_oldBPM == undefined)
+    {
+        __VinylWarning("Voice / Pattern \"", _voiceOrPattern, "\" does not have a BPM associated with it");
+        return 1;
+    }
+    else
+    {
+        return _newBPM / _oldBPM;
+    }
+}

--- a/scripts/VinylGetPitchForBPM/VinylGetPitchForBPM.yy
+++ b/scripts/VinylGetPitchForBPM/VinylGetPitchForBPM.yy
@@ -1,0 +1,13 @@
+{
+  "$GMScript":"v1",
+  "%Name":"VinylGetPitchForBPM",
+  "isCompatibility":false,
+  "isDnD":false,
+  "name":"VinylGetPitchForBPM",
+  "parent":{
+    "name":"BPM",
+    "path":"folders/Vinyl/BPM.yy",
+  },
+  "resourceType":"GMScript",
+  "resourceVersion":"2.0",
+}

--- a/vinyl.resource_order
+++ b/vinyl.resource_order
@@ -115,6 +115,7 @@
     {"name":"VinylGetLength","order":2,"path":"scripts/VinylGetLength/VinylGetLength.yy",},
     {"name":"VinylGetLoop","order":1,"path":"scripts/VinylGetLoop/VinylGetLoop.yy",},
     {"name":"VinylGetPitch","order":1,"path":"scripts/VinylGetPitch/VinylGetPitch.yy",},
+    {"name":"VinylGetPitchForBPM","order":7,"path":"scripts/VinylGetPitchForBPM/VinylGetPitchForBPM.yy",},
     {"name":"VinylGetPosition","order":7,"path":"scripts/VinylGetPosition/VinylGetPosition.yy",},
     {"name":"VinylGetSystemPressure","order":9,"path":"scripts/VinylGetSystemPressure/VinylGetSystemPressure.yy",},
     {"name":"VinylGetTrackPosition","order":10,"path":"scripts/VinylGetTrackPosition/VinylGetTrackPosition.yy",},

--- a/vinyl.yyp
+++ b/vinyl.yyp
@@ -154,6 +154,7 @@
     {"id":{"name":"VinylGetLoop","path":"scripts/VinylGetLoop/VinylGetLoop.yy",},},
     {"id":{"name":"VinylGetMetadata","path":"scripts/VinylGetMetadata/VinylGetMetadata.yy",},},
     {"id":{"name":"VinylGetPitch","path":"scripts/VinylGetPitch/VinylGetPitch.yy",},},
+    {"id":{"name":"VinylGetPitchForBPM","path":"scripts/VinylGetPitchForBPM/VinylGetPitchForBPM.yy",},},
     {"id":{"name":"VinylGetPosition","path":"scripts/VinylGetPosition/VinylGetPosition.yy",},},
     {"id":{"name":"VinylGetSystemPressure","path":"scripts/VinylGetSystemPressure/VinylGetSystemPressure.yy",},},
     {"id":{"name":"VinylGetTrackPosition","path":"scripts/VinylGetTrackPosition/VinylGetTrackPosition.yy",},},


### PR DESCRIPTION
This PR adds in a new function `VinylGetPitchForBPM` to Vinyl's BPM API and a test in the BPM test object in response to #128. The function will return a multiplier (`newBPM / oldBPM`) to then modulate the pitch using `VinylSetPitch`.